### PR TITLE
Elaborate GNU/Linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ICQ WIM protocol for libpurple
 
 # Installation #
 ## Linux install ##
-Download latest builds from https://bamboo.pidgin.im/browse/ICYQUE-EIONROBB/latestSuccessful/artifact/shared/builds/
+Download latest builds from https://bamboo.pidgin.im/browse/ICYQUE-EIONROBB/latestSuccessful/artifact/shared/builds/ and copy into ~/.purple/plugins/ directory.
 
 ### Manual Compiling ###
 Requires devel headers/libs for libpurple and libjson-glib [libglib2.0-dev, libjson-glib-dev and libpurple-dev]


### PR DESCRIPTION
Similar to existing Windows entry. I didn't mention json-glib dependency though because at least [on Arch](https://www.archlinux.org/packages/extra/x86_64/json-glib/) it's required by many other packages, including GTK3, so it's unlikely that one wouldn't have it installed.