### PR TITLE
Set http request timeout to 59 s

### DIFF
--- a/libicyque.c
+++ b/libicyque.c
@@ -316,7 +316,7 @@ icq_fetch_url_with_method(IcyQueAccount *ia, const gchar *method, const gchar *u
 	purple_http_request_set_method(request, method);
 	purple_http_request_header_set(request, "Accept", "*/*");
 	purple_http_request_header_set(request, "Cookie", cookies);
-	purple_http_request_set_timeout(request, 240);
+	purple_http_request_set_timeout(request, 59);
 
 	if (postdata) {
 		if (strstr(url, "/auth/clientLogin") && strstr(postdata, "pwd")) {


### PR DESCRIPTION
In tests with @buchty, we found out that a continuous stream of logout/re-logins comes up with the timeout of 240 s every minute. Setting the timeout below 1 minute solves the issue.