### PR TITLE
icq_response_callback: call cb even if response is empty

### DIFF
--- a/libicyque.c
+++ b/libicyque.c
@@ -307,9 +307,14 @@ icq_response_callback(PurpleHttpConnection *http_conn,
 
 		purple_debug_misc("icyque", "Got response: %s\n", body);
 
-		if (conn->callback && root != NULL) {
-			conn->callback(conn->ia, json_node_get_object(root), conn->user_data);
+		if (conn->callback) {
+			if (root != NULL) {
+				conn->callback(conn->ia, json_node_get_object(root), conn->user_data);
+			} else {
+				conn->callback(conn->ia, NULL, conn->user_data);
+			}
 		}
+
 	}
 
 	g_object_unref(parser);


### PR DESCRIPTION
@isra17 or @slaroche review plz!

cc @jpcaissy if you still want to be tagged in PRs ;)

``json_parser_load_from_data`` does not return False when parsing empty strings as it does not fail. We must handle cases where the empty (or spaces-only) body was parsed successfully and ``root`` is ``NULL``.

In the specific case that I was investigating, this happened when the request is canceled due to a timeout.

\\cc @EionRobb Since you have made me a contributor to this repository, I will prioritize opening PRs here so that the community can benefit from Flared's work.